### PR TITLE
Verify runtime support for captureStackTrace

### DIFF
--- a/egads.js
+++ b/egads.js
@@ -25,7 +25,9 @@ BaseError.extend = function(message, status, name, fields){
 		this.message = args.message || this.message;
 		this.fields  = args.fields  || this.fields;
 
-		Error.captureStackTrace(this, this.constructor);
+        if (Error.captureStackTrace) {
+		    Error.captureStackTrace(this, this.constructor);
+        }
 	};
 	subError.extend = this.extend;
 


### PR DESCRIPTION
Some browsers (like Firefox) do not support `captureStackTrace`.  This
leads to a runtime error (`Error.captureStackTrace is not a function`)
obscuring the actual error that egads captures.

This PR checks for the existance of `captureStackTrace` before calling
it.